### PR TITLE
Simplified link underline to avoid issues

### DIFF
--- a/assets/styles/base/_typography.scss
+++ b/assets/styles/base/_typography.scss
@@ -3,7 +3,7 @@
 
 body {
     @include font-smoothing(on);
-    background-color: $base-background-color;
+    // background-color: $base-background-color;
     color: $base-font-color;
     font-family: $base-font-family;
     font-size: $base-font-size;
@@ -45,9 +45,9 @@ h6 {
   margin: 0;
   font-size: 1em;
   font-family: $base-font-family;
-  font-weight: 600;
+  font-weight: 400;
   text-transform: uppercase;
-  text-rendering: optimizeLegibility; // Fix the character spacing for headings
+  text-rendering: optimizeLegibility; // Fix the character spacing for headings ? this doesn’t seem to have any effect - nk
 }
 
 p {
@@ -63,10 +63,11 @@ a {
 
   &:hover {
     color: $hover-link-color;
-    text-decoration: none;
+    text-decoration: underline;
   }
 
-  &:hover::after {
+/*
+&:hover::after {
     content: "";
     position: absolute;
     bottom: 0px;
@@ -76,6 +77,7 @@ a {
     background: $hover-link-color;
     background: linear-gradient(left,$hover-link-color 100%);
   }
+*/
 
   &:active,
   // &:focus


### PR DESCRIPTION
Removed linear-gradient CSS because it conflicted with link icons that also use the ::after selector.